### PR TITLE
Join queries with newlines

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -31,7 +31,7 @@ function splitIntoQueries (str) {
 
   // join the different lines of single queries
   for (let key of Object.keys(result)) {
-    result[key] = result[key].join(' ').trim()
+    result[key] = result[key].join('\n').trim()
   }
 
   // if we have both unnamed and named queries, throw an error


### PR DESCRIPTION
By joining them with space, single line comments `--` will break things. Haven't tested this. Might it break some of the parsing?