### PR TITLE
::cast in postgres are not parameters

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -175,7 +175,7 @@ const OBJECT_PARAMETER_MODIFIERS = ['$', '@']
 */
 function validateParameters (parameters, sql) {
   const regexAnonymous = /:\?/g
-  const regexNamed = /:([~!@$*]*)([a-zA-Z0-9_]+)({.+})*/g
+  const regexNamed = /(?:[^:]):([~!@$*]*)([a-zA-Z0-9_]+)({.+})*/g
   const missingParameters = []
   const undefinedParameters = []
   const parametersOptions = {}

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -175,7 +175,8 @@ const OBJECT_PARAMETER_MODIFIERS = ['$', '@']
 */
 function validateParameters (parameters, sql) {
   const regexAnonymous = /:\?/g
-  const regexNamed = /(?:[^:]):([~!@$*]*)([a-zA-Z0-9_]+)({.+})*/g
+  const regexNamed = /:(:{0,1}[~!@$*]*)([a-zA-Z0-9_]+)({.+})*/g
+  const regexCast = /^::/
   const missingParameters = []
   const undefinedParameters = []
   const parametersOptions = {}
@@ -191,7 +192,7 @@ function validateParameters (parameters, sql) {
   // find and validate all named parameters
   let namedParameter
   while ((namedParameter = regexNamed.exec(sql)) !== null) {
-    if (namedParameter != null) {
+    if (namedParameter != null && ! regexCast.test(namedParameter[0])) {
       const namedParameterName = namedParameter[1] + namedParameter[2]
 
       parametersOptions[namedParameterName] = {


### PR DESCRIPTION
updates the named parameter regex so that ```SELECT '{}'::int[];``` works