### PR TITLE
Add type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,20 @@
+export type PuresqlQueryParameters = Record<string, any>;
+
+export type PuresqlAdapter = {
+  query: <T = any>(query: string) => Promise<T[]>;
+  escape: (parameter: unknown) => string;
+  escapeIdentifier: (identifier: unknown) => string;
+};
+
+export type PuresqlQuery<T = any> = (parameters: PuresqlQueryParameters, adapter: PuresqlAdapter) => Promise<T>;
+
+export function defineQuery<T = any>(sql: string): PuresqlQuery<T>;
+
+export function loadQueries(filePath): Record<string, PuresqlQuery>; 
+
+export const adapters = {
+  mysql: (connection: any, debugFn: (msg: string) => void) => PuresqlAdapter,
+  sqlite: (connection: any, debugFn: (msg: string) => void) => PuresqlAdapter,
+  mssql: (connection: any, debugFn: (msg: string) => void) => PuresqlAdapter,
+  pg: (connection: any, debugFn: (msg: string) => void) => PuresqlAdapter,
+};

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "engines": {
     "node": ">= 6.0.0"
   },
+  "types": "index.d.ts",
   "main": "index.js",
   "scripts": {
     "test": "nyc mocha --recursive --exit",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "node": ">= 6.0.0"
   },
   "types": "index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neonerd/puresql.git"
+  },
   "main": "index.js",
   "scripts": {
     "test": "nyc mocha --recursive --exit",


### PR DESCRIPTION
## Quick summary ##

 - Added file for typescript users `index.d.ts`
 - Added repository link on `package.json` file

## What is new ##
This PR will add a `index.d.ts` file that will help typescript users to use `puresql` package.

So far, they need to defined their own types and this can make them move away from `puresql`

Also, I've added the link to this repo on `package.json` which will appear on `npmjs`.

## How to test it ##
checkout on the branch that contains the typedef file:
```
git checkout typedefs
```
Create a new directory and init a npm pacakge (I did on the sibling level of puresql directory):
```
  $ mkdir test-package
  $ cd test-package
  $ npm init -y
```
Add puresql path as a dependency of the new `package.json`:
```
{
  "name": "test-puresql",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "dependencies": {
    "puresql": "file:../puresql" <<<<< This may vary depending of where you executed "npm init"
  },
  "keywords": [],
  "author": "",
  "license": "ISC"
}
```
execute npm install:
```
$ npm install
```
create a **index.ts** file and play around with puresql
```
import puresql from 'puresql';
```

