### PR TITLE
fix: Replacement was losing parts of the parameter

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -253,7 +253,7 @@ function parseQuery (parameters, sql, adapter) {
 
       sql = sql.replace(
           new RegExp(parsedParameters.parametersOptions[parameterKey].strToReplace, 'g'),
-          escapeParameter(parameters[parameterKey], parsedParameters.parametersOptions[parameterKey], adapter)
+          () => escapeParameter(parameters[parameterKey], parsedParameters.parametersOptions[parameterKey], adapter)
         )
     }
   }
@@ -262,7 +262,7 @@ function parseQuery (parameters, sql, adapter) {
   parsedParameters.undefinedParameters.map(undefinedParameterKey => {
       sql = sql.replace(
           new RegExp(parsedParameters.parametersOptions[undefinedParameterKey].strToReplace, 'g'),
-          escapeParameter(parameters[undefinedParameterKey], parsedParameters.parametersOptions[undefinedParameterKey], adapter)
+          () => escapeParameter(parameters[undefinedParameterKey], parsedParameters.parametersOptions[undefinedParameterKey], adapter)
         )
   })
 

--- a/test/index.js
+++ b/test/index.js
@@ -165,6 +165,11 @@ describe('query parser', () => {
     ).to.equal('SELECT * FROM user ORDER BY id ')
   })
 
+  it('should preserve parameter\'s $$', () => {
+    expect(
+      parser.parseQuery({'str': 'My string contain $$'}, 'SELECT \':str\';', adapter)
+    ).to.equal('SELECT \'My string contain $$\';')
+  })
 })
 
 // FILE PARSER


### PR DESCRIPTION
This PR fixes special cases for string replace method: 

```js
'replace HERE with something'.replace('HERE', '$$');
// 'replace $ with something'
```

There are other cases, you can see in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement).

Instead of passing directly the replace string, I wrapped it with an arrow function. This will preserve the string since it won't fall into those special cases.
